### PR TITLE
Fix enum wire values

### DIFF
--- a/generator_test.go
+++ b/generator_test.go
@@ -155,6 +155,69 @@ class HelperApiRuntimeTest {
 	runGradle(t, project, "test")
 }
 
+func TestEnumWireValuesRuntime(t *testing.T) {
+	schema := `
+webrpc = v1
+
+name = EnumWire
+version = v1.0.0
+basepath = /rpc
+
+enum WalletType: string
+  - Ethereum = "ethereum"
+  - SmartWallet = "smart-wallet"
+
+struct EchoRequest
+  - walletType: WalletType
+
+struct EchoResponse
+  - walletType: WalletType
+
+service EnumWire
+  - Echo(EchoRequest) => (EchoResponse)
+`
+
+	output := generateKotlin(t, schema)
+	requireContains(t, output, `Ethereum("ethereum")`)
+	requireContains(t, output, `SmartWallet("smart-wallet")`)
+
+	project := writeGradleProject(t, "enum-wire-values", map[string]string{
+		"src/main/kotlin/EnumWireClient.kt": output,
+		"src/test/kotlin/EnumWireValuesRuntimeTest.kt": `
+import io.webrpc.client.EnumWireApi
+import io.webrpc.client.EchoRequest
+import io.webrpc.client.WalletType
+import io.webrpc.client.WalletTypeSerializer
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EnumWireValuesRuntimeTest {
+    @Test
+    fun explicitEnumWireValuesRoundTrip() {
+        val request = EchoRequest(walletType = WalletType.Ethereum)
+        val body = EnumWireApi.Echo.encodeRequest(request)
+        assertEquals("""{"walletType":"ethereum"}""", body)
+
+        val response = EnumWireApi.Echo.decodeResponse("""{"walletType":"smart-wallet"}""")
+        assertEquals(WalletType.SmartWallet, response.walletType)
+    }
+
+    @Test
+    fun unknownEnumWireValueFallsBack() {
+        val decoded = Json.decodeFromString(WalletTypeSerializer, "\"unexpected\"")
+        assertEquals(WalletType.UNKNOWN_DEFAULT, decoded)
+    }
+}
+`,
+	}, gradleDeps{
+		withCoroutines:    true,
+		withSerialization: true,
+	})
+
+	runGradle(t, project, "test")
+}
+
 func TestNullOptionalGeneration(t *testing.T) {
 	schema := `
 webrpc = v1

--- a/types.go.tmpl
+++ b/types.go.tmpl
@@ -11,7 +11,7 @@
 @Serializable(with = {{$type.Name}}Serializer::class)
 enum class {{$type.Name}}(val wireValue: String) {
 {{- range $_, $field := $type.Fields}}
-    {{$field.Name}}("{{$field.Name}}"),
+    {{$field.Name}}("{{$field.Value}}"),
 {{- end}}
     UNKNOWN_DEFAULT("UNKNOWN_DEFAULT");
 

--- a/types.go.tmpl
+++ b/types.go.tmpl
@@ -11,7 +11,11 @@
 @Serializable(with = {{$type.Name}}Serializer::class)
 enum class {{$type.Name}}(val wireValue: String) {
 {{- range $_, $field := $type.Fields}}
+    {{- if eq $type.Type.Expr "string" }}
     {{$field.Name}}("{{$field.Value}}"),
+    {{- else }}
+    {{$field.Name}}("{{$field.Name}}"),
+    {{- end }}
 {{- end}}
     UNKNOWN_DEFAULT("UNKNOWN_DEFAULT");
 


### PR DESCRIPTION
## Summary
- use explicit RIDL enum values for Kotlin string enum wire values instead of enum identifiers
- add regression coverage for explicit string enum serialization and deserialization

## Why
The Kotlin generator was emitting enum names like `Ethereum` and `Native` as wire values even when the schema defined explicit string values like `ethereum` and `native`. That breaks request encoding and response decoding against APIs that validate the RIDL wire values.

## Validation
- `go test ./...`
- generated a temporary Kotlin client from the `waas` `oms-refactor` schema snapshot to confirm the emitted enum wire values are explicit schema values
